### PR TITLE
Fix path resolution for pip config and env files

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -23,7 +23,6 @@ def test_yapenv_read_config(
 
 def test_yapenv_read_pip_config_file(
     config: YAPENVConfig = None,
-    values: dict = None,
 ):
     config = config or YAPENVConfig.load(TEST_PATH)
     config_path = os.path.abspath(os.path.join(TEST_PATH, config.pip_config_path))

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,4 +1,5 @@
 import re
+import os
 from typing import List
 from tests.consts import TEST_PATH
 from yapenv.config import YAPENVConfig
@@ -18,6 +19,18 @@ def test_yapenv_read_config(
     for key in values.keys():
         val = config.find(key)[0]
         assert val == values[key], f"Invalid config value {key}, {values[key]} != {val}"
+
+
+def test_yapenv_read_pip_config_file(
+    config: YAPENVConfig = None,
+    values: dict = None,
+):
+    config = config or YAPENVConfig.load(TEST_PATH)
+    config_path = os.path.abspath(os.path.join(TEST_PATH, config.pip_config_path))
+
+    assert os.path.isfile(
+        config_path
+    ), f"Expected config file @ {config_path} is missing, invalid path or invalid path resolve"
 
 
 def test_yapenv_read_requirements(

--- a/tests/test_files/.yapenv.yaml
+++ b/tests/test_files/.yapenv.yaml
@@ -3,5 +3,7 @@ requirements:
   - import: requirements.txt
 venv_directory: .venv
 
+pip_config_path: "../../pip.conf"
+
 test_val: "parent"
 parent_val: "parent"

--- a/yapenv/config.py
+++ b/yapenv/config.py
@@ -62,7 +62,8 @@ class YAPENVConfig(CascadingConfig):
         "pip_config_path",
         "env_file",
     ]
-    """A collection of dictionary keys to resolve as paths, when calling init.
+    """A collection of configuration keys to resolve as paths. The resolve will be called relative
+    to the location of the config file.
     """
 
     @property


### PR DESCRIPTION
The fix allows for path key resolution for pip_config_path and env_file, so that inherited configurations are loaded properly.